### PR TITLE
Use underscore for unused arguments.

### DIFF
--- a/pkg/frontend/nvme_test.go
+++ b/pkg/frontend/nvme_test.go
@@ -8,5 +8,5 @@ import (
 	"testing"
 )
 
-func TestCreateNVMeController(t *testing.T) {
+func TestCreateNVMeController(_ *testing.T) {
 }

--- a/pkg/frontend/spdk_test.go
+++ b/pkg/frontend/spdk_test.go
@@ -8,6 +8,6 @@ import (
 	"testing"
 )
 
-func TestSpdk_Call(t *testing.T) {
+func TestSpdk_Call(_ *testing.T) {
 
 }


### PR DESCRIPTION
Due to golangci update to 1.52.0 version where unused arguments are checked, all unused variables should be replaced with _ to pass the check