### PR TITLE
Allow same-named headings with different parents in md-files

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,3 @@
+{
+	"MD024": { "siblings_only": true }
+}


### PR DESCRIPTION
Some files, like CHANGELOG.md, require same-named sections for different parent sections.
This change introduces repo-level markdownlint configuration file and enables this
behavior according to [this recommendation](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md024---multiple-headings-with-the-same-content).